### PR TITLE
refind fix #3

### DIFF
--- a/hibernator
+++ b/hibernator
@@ -55,20 +55,12 @@ has_resume_hook () {
 }
 
 resume_boot_option() {
+	root_part=$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")
+	swap_part=$(find /dev/disk/ | grep "$(awk '$3=="swap" {print $1; exit}' /etc/fstab | cut -d= -f 2)")
     if [[ -f /swapfile ]]; then
-        echo "resume=$(root_part) resume_offset=$(hibernate_offset)"
+        echo "resume=$root_part resume_offset=$(hibernate_offset)"
     elif has_swap_part; then
-        echo "resume=$(swap_part)"
-    fi
-}
-
-grub_resume_boot_option() {
-	grub_root_part=$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")
-	grub_swap_part=$(find /dev/disk/ | grep "$(awk '$3=="swap" {print $1; exit}' /etc/fstab | cut -d= -f 2)")
-    if [[ -f /swapfile ]]; then
-        echo "resume=$grub_root_part resume_offset=$(hibernate_offset)"
-    elif has_swap_part; then
-        echo "resume=$grub_swap_part"
+        echo "resume=$swap_part"
     fi
 }
 
@@ -87,12 +79,12 @@ add_kernel_parameters() {
 	if [ -e /etc/default/grub ]; then
 		cp /etc/default/grub /etc/default/grub.old
 		sed -i "s/[[:blank:]]*$//" /etc/default/grub
-		sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s~\"$~ $(grub_resume_boot_option)\"~g" /etc/default/grub && update-grub
+		sed -i "/^GRUB_CMDLINE_LINUX_DEFAULT/ s~\"$~ $(resume_boot_option)\"~g" /etc/default/grub && update-grub
 	fi
 	#Add needed kernel parameters to refind
 	if [ -e /boot/refind_linux.conf ]; then
 		cp /boot/refind_linux.conf /boot/refind_linux.conf.old
-		grep -q "$(resume_boot_option)" /boot/refind_linux.conf || sed -i 's/"$/ '"$(resume_boot_option)"'"/' /boot/refind_linux.conf
+		grep -q "$(resume_boot_option)" /boot/refind_linux.conf || sed -i 's:"$: '"$(resume_boot_option)"'":' /boot/refind_linux.conf
 	fi	
 }
 


### PR DESCRIPTION
- Fix for empty resume parameter in rEFInd
- Removed incorrect function
- Renamed `grub_resume_boot_option` to `resume_boot_option`, since it provides options for other bootloaders too