### PR TITLE
Update PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Chrysostomus @forum.manjaro.org
 pkgname=hibernator
-pkgver=0.1
+pkgver=0.2
 pkgrel=1
 pkgdesc="Script to automate setting up hibernation"
 arch=(any)
@@ -8,7 +8,7 @@ url="https://github.com/Chrysostomus/$pkgname"
 license=("MIT")
 depends=('sed' 'gawk' 'bash' 'mkinitcpio')
 makedepends=('git')
-source=("git://github.com/Chrysostomus/$pkgname")
+source=("git+https://github.com/Chrysostomus/$pkgname")
 md5sums=('SKIP')
 
 package () {


### PR DESCRIPTION
This should fix #6 

But please keep in mind that I'm not familiar with AUR package. By looking at other PKGBUILD this should fix the "The unauthenticated git protocol on port 9418 is no longer supported."