### PR TITLE
fix "sed -e unterminated `s' command" error

### DIFF
--- a/hibernator
+++ b/hibernator
@@ -63,7 +63,7 @@ resume_boot_option() {
 }
 
 grub_resume_boot_option() {
-  grub_root_part=$(echo "$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")" | head -n1)
+  	grub_root_part=$(echo "$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")" | head -n1)
 	grub_swap_part=$(find /dev/disk/ | grep "$(awk '$3=="swap" {print $1; exit}' /etc/fstab | cut -d= -f 2)")
     if [[ -f /swapfile ]]; then
         echo "resume=$grub_root_part resume_offset=$(hibernate_offset)"

--- a/hibernator
+++ b/hibernator
@@ -63,7 +63,7 @@ resume_boot_option() {
 }
 
 grub_resume_boot_option() {
-	grub_root_part=$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")
+  grub_root_part=$(echo "$(find /dev/disk/ | grep "$(awk '$2~/^\/$/ {print $1}' /etc/fstab | cut -d= -f 2)")" | head -n1)
 	grub_swap_part=$(find /dev/disk/ | grep "$(awk '$3=="swap" {print $1; exit}' /etc/fstab | cut -d= -f 2)")
     if [[ -f /swapfile ]]; then
         echo "resume=$grub_root_part resume_offset=$(hibernate_offset)"


### PR DESCRIPTION
for some reason, the output of `grub_root_part` had two lines, so i took the head of that and now the script works again